### PR TITLE
Add Full Page Heuristic & Eval On QMP Simple

### DIFF
--- a/notebooks/full_page_heuristic.ipynb
+++ b/notebooks/full_page_heuristic.ipynb
@@ -1,0 +1,453 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "84c5e2e0",
+   "metadata": {},
+   "source": [
+    "# Test Out Heuristic Approach on Simple Qampari Questions\n",
+    "My hypothesis was that a really simple heuristic could solve simple QAMPARI questions: do a BM25 search on full pages with the question & count recall based on exact match in the retrieved pages.\n",
+    "\n",
+    "Steps:\n",
+    "\n",
+    "1. Extract the simple qampari questions\n",
+    "2. Postprocess the wikipedia dump into a page index for pyserini\n",
+    "3. Get the results for 100 and 500 hits\n",
+    "Additionally, as a sanity check I would expect that doing a BM25 search with the answer would bring up pages that contain the answer, so test this too.\n",
+    "\n",
+    "## Current Results\n",
+    "49.7% miss in top 100 41.5% miss in top 500 26.5% miss in answer query top 100\n",
+    "\n",
+    "These results are pretty unexpected suggesting that I'm doing something wrong."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b99f503",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f8ba2acb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/ext3/miniconda3/envs/multiqa/lib/python3.9/site-packages/torch/cuda/__init__.py:52: UserWarning: CUDA initialization: Found no NVIDIA driver on your system. Please check that you have an NVIDIA GPU and installed a driver from http://www.nvidia.com/Download/index.aspx (Triggered internally at  /opt/conda/conda-bld/pytorch_1607370192109/work/c10/cuda/CUDAFunctions.cpp:100.)\n",
+      "  return torch._C._cuda_getDeviceCount() > 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import defaultdict\n",
+    "\n",
+    "import json\n",
+    "import jsonlines\n",
+    "import os\n",
+    "\n",
+    "from pyserini.search.lucene import LuceneSearcher"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f58ee161",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b60d71d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qp_simple_data = json.load(open('/scratch/ddr8143/multiqa/qampari_data/qp_simple_train.json'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8b322765",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index_path = \"/scratch/ddr8143/multiqa/indexes/full_page_qampari_wikidata_index\"\n",
+    "searcher = LuceneSearcher(index_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5868ce6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the question as the query\n",
+    "def query_question(searcher, qdata, k):\n",
+    "    q = qdata['question_text']\n",
+    "    alist = [a['answer_text'] for a in qdata['answer_list']]\n",
+    "    hits = searcher.search(q, k=k)\n",
+    "    ans_contained = defaultdict(list)\n",
+    "    for a in alist:\n",
+    "        for i, hit in enumerate(hits):\n",
+    "            if a.lower() in hit.raw.lower():\n",
+    "                ans_contained[a].append(i)\n",
+    "        ans_contained[a]\n",
+    "    return ans_contained"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "9bf53b4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the answers at the query\n",
+    "def query_answers(searcher, qdata, k):\n",
+    "    q = qdata['question_text']\n",
+    "    alist = [a['answer_text'] for a in qdata['answer_list']]\n",
+    "    ans_hits = defaultdict(list)\n",
+    "    for a in alist:\n",
+    "        hits = searcher.search(a, k=k)\n",
+    "        for i, hit in enumerate(hits):\n",
+    "            if a.lower() in hit.raw.lower():\n",
+    "                ans_hits[a].append(i)\n",
+    "        ans_hits[a]\n",
+    "    return ans_hits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d02f3d70",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca7cf112",
+   "metadata": {},
+   "source": [
+    "**Run hit queries and/or load output**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e35f1190",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run Queries on the full simple dataset\n",
+    "hit_data_out_path = \"/scratch/ddr8143/multiqa/qampari_data/hit_data.jsonl\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f851ab38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Path already exists: /scratch/ddr8143/multiqa/qampari_data/hit_data.jsonl\n"
+     ]
+    }
+   ],
+   "source": [
+    "if not os.path.exists(hit_data_out_path):\n",
+    "    fp = open(hit_data_out_path, 'w+')\n",
+    "    with jsonlines.Writer(fp) as writer:\n",
+    "        for qd in qp_simple_data:\n",
+    "            qq100 = query_question(searcher, qd, 100)\n",
+    "            qq500 = query_question(searcher, qd, 500)\n",
+    "            qa100 = query_answers(searcher, qd, 100)\n",
+    "            qdata_out = {\n",
+    "                \"question_data\": qd,\n",
+    "                \"query_question_contains_answer_k100\": qq100,\n",
+    "                \"query_question_contains_answer_k500\": qq500,\n",
+    "                \"query_answers_contains_answer_k100\": qa100,\n",
+    "            }\n",
+    "            writer.write(qdata_out)\n",
+    "    fp.close()\n",
+    "else:\n",
+    "    print(f\"Path already exists: {hit_data_out_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "0f0d2d12",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "28574"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load the output\n",
+    "all_hits_data = []\n",
+    "with jsonlines.Reader(open(hit_data_out_path)) as reader:\n",
+    "    for obj in reader:\n",
+    "        all_hits_data.append(obj)\n",
+    "len(all_hits_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f427e4f2",
+   "metadata": {},
+   "source": [
+    "**Look at some examples**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "59aeb838",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'To Let': [16, 25, 38],\n",
+       " 'Kalloori': [],\n",
+       " 'Thenmerku Paruvakaatru': [],\n",
+       " 'A Little Dream': [],\n",
+       " 'Paradesi': [],\n",
+       " 'Sawaari': [55]}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Look at some examples\n",
+    "all_hits_data[0]['query_question_contains_answer_k100']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1a796ffd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'To Let': [16, 25, 38, 155, 206, 210, 257, 321, 408],\n",
+       " 'Kalloori': [],\n",
+       " 'Thenmerku Paruvakaatru': [],\n",
+       " 'A Little Dream': [],\n",
+       " 'Paradesi': [],\n",
+       " 'Sawaari': [55]}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_hits_data[0]['query_question_contains_answer_k500']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "e6d15df2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The first 10 answer hits:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'To Let': [1, 2, 3, 34, 42, 49, 63],\n",
+       " 'Kalloori': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],\n",
+       " 'Thenmerku Paruvakaatru': [0, 1, 2, 3, 4, 5, 6, 8],\n",
+       " 'A Little Dream': [4, 5, 6, 23, 28, 84],\n",
+       " 'Paradesi': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],\n",
+       " 'Sawaari': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(\"The first 10 answer hits:\")\n",
+    "{k: v[:10] for k, v in all_hits_data[0]['query_answers_contains_answer_k100'].items()}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b442fd96",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c40f4746",
+   "metadata": {},
+   "source": [
+    "## Now Analyze Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "3b92e800",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_ans = []\n",
+    "missing_top_100 = []\n",
+    "missing_top_500 = []\n",
+    "missing_in_own = []\n",
+    "for i in range(len(all_hits_data)):\n",
+    "    top_100 = all_hits_data[i]['query_question_contains_answer_k100']\n",
+    "    top_500 = all_hits_data[i]['query_question_contains_answer_k500']\n",
+    "    top_100_own = all_hits_data[i]['query_answers_contains_answer_k100'];\n",
+    "    all_ans.append([a for a, _ in top_100.items()])\n",
+    "    missing_top_100.append([a for a, v in top_100.items() if len(v) == 0])\n",
+    "    missing_top_500.append([a for a, v in top_500.items() if len(v) == 0])\n",
+    "    missing_in_own.append([a for a, v in top_100_own.items() if len(v) == 0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "4aaabb60",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Which software, art, etc. has Charles McPherson as performer?\n",
+      "             all answers: 16 ['Come Play with Me (album)', 'Con Alma!', 'Live in Tokyo', 'Bebop Revisited!', \"McPherson's Mood\", 'The Quintet/Live!', 'Free Bop!', 'From This Moment On!', \"Today's Man\", 'Beautiful!', 'Charles McPherson', 'Horizons', 'First Flight Out', 'Manhattan Nocturne (album)', 'Siku Ya Bibi', 'New Horizons']\n",
+      "\n",
+      "    missing from top 100: 11 ['Con Alma!', 'Live in Tokyo', \"McPherson's Mood\", 'The Quintet/Live!', 'Free Bop!', 'From This Moment On!', \"Today's Man\", 'Beautiful!', 'First Flight Out', 'Siku Ya Bibi', 'New Horizons']\n",
+      "\n",
+      "    missing from top 500: 4 ['Con Alma!', \"Today's Man\", 'Beautiful!', 'Siku Ya Bibi']\n",
+      "\n",
+      " missing from own search: 5 ['Free Bop!', 'From This Moment On!', 'Beautiful!', 'First Flight Out', 'Siku Ya Bibi']\n"
+     ]
+    }
+   ],
+   "source": [
+    "k = 100\n",
+    "print(all_hits_data[k]['question_data']['question_text'])\n",
+    "print(f'             all answers: {len(all_ans[k])}',  all_ans[k])\n",
+    "print()\n",
+    "print(f'    missing from top 100: {len(missing_top_100[k])}', missing_top_100[k])\n",
+    "print()\n",
+    "print(f'    missing from top 500: {len(missing_top_500[k])}', missing_top_500[k])\n",
+    "print()\n",
+    "print(f' missing from own search: {len(missing_in_own[k])}', missing_in_own[k])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e77eda6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "1e3fd7f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "percent_results = {\n",
+    "    \"perc_miss_top_100\": [len(missing_top_100[k]) * 100.0 / len(all_ans[k]) for k in range(len(all_ans))],\n",
+    "    \"perc_miss_top_500\": [len(missing_top_500[k]) * 100.0 / len(all_ans[k]) for k in range(len(all_ans))],\n",
+    "    \"perc_miss_own_100\": [len(missing_in_own[k]) * 100.0 / len(all_ans[k]) for k in range(len(all_ans))],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "3c55cd51",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "perc_miss_top_100 | min 0.00 avg 49.67 max 100.00\n",
+      "perc_miss_top_500 | min 0.00 avg 41.48 max 100.00\n",
+      "perc_miss_own_100 | min 0.00 avg 26.53 max 100.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "for pname, p in percent_results.items():\n",
+    "    print(f\"{pname:15} | min {min(p):0.2f} avg {sum(p)/len(p):0.2f} max {max(p):0.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1a35def",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Added a notebook, `full_page_heuristic.ipynb` which takes the full page qampari index and uses it to get top100, top500 on question searches, and top100 on answer searches for qampari simple.

Then analyzes the results (where these are answer percentages missing).  Results are unexpectedly bad so this is probably worth more investigation (exact match is bad? tokenization effects things? unclear).

```
perc_miss_top_100 | min 0.00 avg 49.67 max 100.00
perc_miss_top_500 | min 0.00 avg 41.48 max 100.00
perc_miss_own_100 | min 0.00 avg 26.53 max 100.00
```