### PR TITLE
[Wiki Processing] Integrate WikiChunker into DataManager

### DIFF
--- a/multiqa_utils/wiki_processing_utils.py
+++ b/multiqa_utils/wiki_processing_utils.py
@@ -303,12 +303,13 @@ class WikiChunker(FileProcessor):
         self.logger = logger
 
     def get_job_name(self, stage):
-        return f'{stage}_{self.cfg.shard_num}'
+        return f'{stage}_{self.cfg.shard_ind}'
 
     def select_job_files(self):
-        # TODO: get files from config
-        self.files = []
-        assert False
+        glob_all = fu.get_recursive_files(self.input_dir)
+        all_files = [f for f in all_files if '/wiki_' in f]
+        shard_files = ru.get_curr_shard(all_files, cfg.shard_num, cfg.shard_ind)
+        self.files = shard_files
 
     def get_output_from_inpath(self, file_path):
         # basepath/AA/wiki_00

--- a/multiqa_utils/wiki_processing_utils.py
+++ b/multiqa_utils/wiki_processing_utils.py
@@ -341,26 +341,35 @@ class WikiChunker(FileProcessor):
                         num_chars = len(chunk['chunk_text'])
                         num_toks = chunk['chunk_end_ind'] - chunk['chunk_start_ind']
                         md.add_to_metric(
-                            'chars', 'chunk', num_chars, metric_type='hist',
+                            'chars',
+                            'chunk',
+                            num_chars,
+                            metric_type='hist',
                         )
                         md.add_to_metric(
-                            'toks', 'chunk', num_toks, metric_type='hist',
+                            'toks',
+                            'chunk',
+                            num_toks,
+                            metric_type='hist',
                         )
-                    max_len_chunk_chars = max([len(c['chunk_text']) for c in page_chunks])
+                    max_len_chunk_chars = max(
+                        [len(c['chunk_text']) for c in page_chunks]
+                    )
                 md.vals['max_num_chunks_per_page'] = max(
                     md.vals['max_num_chunks_per_page'], num_chunks
                 )
             md.vals['avg_num_chunks_per_page'] = (
-                1.0 * md.vals['num_total_chunks'] /
-                md.vals['num_pages_with_text']
+                1.0 * md.vals['num_total_chunks'] / md.vals['num_pages_with_text']
             )
             md.update_agg_stats(no_len=True)
 
             metrics_to_log = [('list_elem', 'file_path', file_path)]
-            metrics_to_log.extend([
-                ('list_elem', v_n, v_d) for v_n, v_d in md.vals.items()
-            ])
-            log_success = self.logger.log_all_to_redis(metrics_to_log, prefix=self.stage_name)
+            metrics_to_log.extend(
+                [('list_elem', v_n, v_d) for v_n, v_d in md.vals.items()]
+            )
+            log_success = self.logger.log_all_to_redis(
+                metrics_to_log, prefix=self.stage_name
+            )
             if not log_success:
                 logging.info(f">> Redis logging failed for metrics: {metrics_to_log}")
         return all_chunks
@@ -438,7 +447,7 @@ class WikiChunker(FileProcessor):
         # Verify all files are in chunking metrics
         failed_files = list(files_set - all_stats.keys())
         tname = 'all_files_in_metrics'
-        test_res[tname] = (len(failed_files) == 0)
+        test_res[tname] = len(failed_files) == 0
         if not test_res[tname]:
             extra_data[tname] = failed_files
 
@@ -448,7 +457,7 @@ class WikiChunker(FileProcessor):
         for fp, fd in all_stats.items():
             if fd['chars_per_chunk_min'] == 0:
                 failed_files.append((fp, fd['chars_per_chunk_min']))
-        test_res[tname] = (len(failed_files) == 0)
+        test_res[tname] = len(failed_files) == 0
         if not test_res[tname]:
             extra_data[tname] = failed_files
 
@@ -457,7 +466,7 @@ class WikiChunker(FileProcessor):
         for fp, fd in all_stats.items():
             if fd['toks_per_chunk_min'] == 0:
                 failed_files.append((fp, fd['toks_per_chunk_min']))
-        test_res[tname] = (len(failed_files) == 0)
+        test_res[tname] = len(failed_files) == 0
         if not test_res[tname]:
             extra_data[tname] = failed_files
 
@@ -468,7 +477,7 @@ class WikiChunker(FileProcessor):
             out_fp = self.get_output_from_inpath(fp)
             if not os.path.exists(out_fp):
                 failed_files.append((fp, out_fp))
-        test_res[tname] = (len(failed_files) == 0)
+        test_res[tname] = len(failed_files) == 0
         if not test_res[tname]:
             extra_data[tname] = failed_files
 
@@ -492,7 +501,7 @@ class WikiChunker(FileProcessor):
             nuc = num_unique_chunks[fp]
             if nc != nuc:
                 failed_files.append((fp, nc, nuc))
-        test_res[tname] = (len(failed_files) == 0)
+        test_res[tname] = len(failed_files) == 0
         if not test_res[tname]:
             extra_data[tname] = failed_files
 
@@ -502,10 +511,9 @@ class WikiChunker(FileProcessor):
             expected_c = all_stats[fp]['num_total_chunks']
             if nuc != expected_c:
                 failed_files.append((fp, nuc, expected_c))
-        test_res[tname] = (len(failed_files) == 0)
+        test_res[tname] = len(failed_files) == 0
         if not test_res[tname]:
             extra_data[tname] = failed_files
-
 
         ## Convert test results into flag
         dump_data = ['']

--- a/multiqa_utils/wiki_processing_utils.py
+++ b/multiqa_utils/wiki_processing_utils.py
@@ -266,7 +266,6 @@ class WikiChunker(FileProcessor):
 
         self.cfg = cfg
         self.input_dir = cfg.wiki_processing.wiki_input_dir
-        self.merge_input_first = cfg.wiki_processing.wiki_input_dir_chunked
         self.chunked_dir = cfg.wiki_processing.wiki_chunked_dir
         self.target_words = cfg.wiki_processing.chunk_target_word_len
         self.max_words = cfg.wiki_processing.chunk_max_word_len

--- a/multiqa_utils/wiki_processing_utils.py
+++ b/multiqa_utils/wiki_processing_utils.py
@@ -372,7 +372,26 @@ class WikiChunker(FileProcessor):
         ]
         return chunks
 
-    def check_is_job_running(self, job_name):
+    def check_verified(self):
+        # TODO: check whether one of the flag files exist
+        # returns info
+        
+
+    def check_run_verified(self):
+        # TODO: call check_verified and if not verified then 
+        # rerun _verify_run
+        assert False
+
+
+    def _verify_run(self):
+        assert self.logger is not None
+        # TODO: this should be run while we have a redis logger
+        # calculate the verification metrics by comparing the expected
+        # files that should have been processed to the files that have
+        # been processed and calculating verification metrics on each
+        # using the Redis metrics and the output file
+        # Then write either job_name.incomplete, job_name.verified, or
+        # job_name.error as described in notion notes for WikiChunker
         assert False
 
     # Returns: [(chunk_start_ind, chunk_end_ind, chunk_text), ...]


### PR DESCRIPTION
Related issue: #31
Works in parallel with: drothermel/utils#8

This PR Currently:
- Updates DataManager according to RedisLogger changes
- Ensures no thrashing of the DataManager state file
- Passes the RedisLogger from DataManager to the WikiChunker
- Selects the relevant input files based on input dir and shard ind
- Calculates and logs metrics in WikiChunker.merge_results
- Uses the metrics and the output file to verify the run was a success + write a flag file
- Updates the DataManager to use the flag file outputs to update the state file

Definitely not tested but the structure for using the WikiChunker + DataManager + RedisLogger is there from start to finish.